### PR TITLE
fix(security): add auth, rate limiting, timing-safe compare, timeouts

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botmaker-dashboard",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "botmaker-dashboard",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -102,6 +102,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -458,6 +459,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -481,6 +483,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1698,8 +1701,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1773,6 +1775,7 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1784,6 +1787,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1833,6 +1837,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2177,6 +2182,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2237,7 +2243,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2326,6 +2331,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2633,8 +2639,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2812,6 +2817,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3587,6 +3593,7 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -3751,7 +3758,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4080,6 +4086,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4132,7 +4139,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4157,6 +4163,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4169,6 +4176,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4182,8 +4190,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -4674,6 +4681,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4753,6 +4761,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5341,6 +5350,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -5864,6 +5874,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/dashboard/src/api.test.ts
+++ b/dashboard/src/api.test.ts
@@ -14,19 +14,26 @@ import {
   addProxyKey,
   deleteProxyKey,
   fetchProxyHealth,
+  setAdminToken,
+  clearAdminToken,
 } from './api';
 
 // Mock fetch
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
+const TEST_TOKEN = 'test-admin-token';
+const AUTH_HEADER = { Authorization: `Bearer ${TEST_TOKEN}` };
+
 describe('API Client', () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    setAdminToken(TEST_TOKEN);
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+    clearAdminToken();
   });
 
   describe('fetchBots', () => {
@@ -44,7 +51,7 @@ describe('API Client', () => {
       const result = await fetchBots();
 
       expect(result).toEqual(bots);
-      expect(mockFetch).toHaveBeenCalledWith('/api/bots');
+      expect(mockFetch).toHaveBeenCalledWith('/api/bots', { headers: AUTH_HEADER });
     });
 
     it('should throw on error response', async () => {
@@ -80,7 +87,7 @@ describe('API Client', () => {
       const result = await fetchBot('bot-1');
 
       expect(result).toEqual(bot);
-      expect(mockFetch).toHaveBeenCalledWith('/api/bots/bot-1');
+      expect(mockFetch).toHaveBeenCalledWith('/api/bots/bot-1', { headers: AUTH_HEADER });
     });
   });
 
@@ -108,7 +115,7 @@ describe('API Client', () => {
       expect(result).toEqual(createdBot);
       expect(mockFetch).toHaveBeenCalledWith('/api/bots', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
         body: JSON.stringify(input),
       });
     });
@@ -124,6 +131,7 @@ describe('API Client', () => {
       await expect(deleteBot('bot-1')).resolves.toBeUndefined();
       expect(mockFetch).toHaveBeenCalledWith('/api/bots/bot-1', {
         method: 'DELETE',
+        headers: AUTH_HEADER,
       });
     });
   });
@@ -138,6 +146,7 @@ describe('API Client', () => {
       await expect(startBot('bot-1')).resolves.toBeUndefined();
       expect(mockFetch).toHaveBeenCalledWith('/api/bots/bot-1/start', {
         method: 'POST',
+        headers: AUTH_HEADER,
       });
     });
   });
@@ -152,6 +161,7 @@ describe('API Client', () => {
       await expect(stopBot('bot-1')).resolves.toBeUndefined();
       expect(mockFetch).toHaveBeenCalledWith('/api/bots/bot-1/stop', {
         method: 'POST',
+        headers: AUTH_HEADER,
       });
     });
   });
@@ -170,7 +180,7 @@ describe('API Client', () => {
       const result = await fetchContainerStats();
 
       expect(result).toEqual(stats);
-      expect(mockFetch).toHaveBeenCalledWith('/api/stats');
+      expect(mockFetch).toHaveBeenCalledWith('/api/stats', { headers: AUTH_HEADER });
     });
   });
 
@@ -191,7 +201,7 @@ describe('API Client', () => {
       const result = await fetchOrphans();
 
       expect(result).toEqual(orphans);
-      expect(mockFetch).toHaveBeenCalledWith('/api/admin/orphans');
+      expect(mockFetch).toHaveBeenCalledWith('/api/admin/orphans', { headers: AUTH_HEADER });
     });
   });
 
@@ -214,6 +224,7 @@ describe('API Client', () => {
       expect(result).toEqual(report);
       expect(mockFetch).toHaveBeenCalledWith('/api/admin/cleanup', {
         method: 'POST',
+        headers: AUTH_HEADER,
       });
     });
   });
@@ -248,7 +259,7 @@ describe('API Client', () => {
       const result = await fetchProxyKeys();
 
       expect(result).toEqual(keys);
-      expect(mockFetch).toHaveBeenCalledWith('/api/proxy/keys');
+      expect(mockFetch).toHaveBeenCalledWith('/api/proxy/keys', { headers: AUTH_HEADER });
     });
   });
 
@@ -268,7 +279,7 @@ describe('API Client', () => {
       expect(result.id).toBe('new-key-id');
       expect(mockFetch).toHaveBeenCalledWith('/api/proxy/keys', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
         body: JSON.stringify({
           vendor: 'openai',
           secret: 'sk-test',
@@ -288,6 +299,7 @@ describe('API Client', () => {
       await expect(deleteProxyKey('key-123')).resolves.toBeUndefined();
       expect(mockFetch).toHaveBeenCalledWith('/api/proxy/keys/key-123', {
         method: 'DELETE',
+        headers: AUTH_HEADER,
       });
     });
   });
@@ -309,7 +321,7 @@ describe('API Client', () => {
       const result = await fetchProxyHealth();
 
       expect(result).toEqual(health);
-      expect(mockFetch).toHaveBeenCalledWith('/api/proxy/health');
+      expect(mockFetch).toHaveBeenCalledWith('/api/proxy/health', { headers: AUTH_HEADER });
     });
   });
 });

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -2,7 +2,40 @@ import type { Bot, CreateBotInput, ContainerStats, OrphanReport, CleanupReport, 
 
 const API_BASE = '/api';
 
+let adminToken: string | null = null;
+
+export function setAdminToken(token: string): void {
+  adminToken = token;
+  localStorage.setItem('admin_token', token);
+}
+
+export function getAdminToken(): string | null {
+  if (!adminToken) {
+    adminToken = localStorage.getItem('admin_token');
+  }
+  return adminToken;
+}
+
+export function clearAdminToken(): void {
+  adminToken = null;
+  localStorage.removeItem('admin_token');
+}
+
+function getAuthHeaders(): HeadersInit {
+  const token = getAdminToken();
+  if (!token) {
+    throw new Error('Not authenticated. Please provide an admin token.');
+  }
+  return {
+    Authorization: `Bearer ${token}`,
+  };
+}
+
 async function handleResponse<T>(response: Response): Promise<T> {
+  if (response.status === 401 || response.status === 403) {
+    clearAdminToken();
+    throw new Error('Authentication failed. Please re-enter your admin token.');
+  }
   if (!response.ok) {
     const data = await response.json().catch(() => ({}));
     throw new Error(data.error || `HTTP error ${response.status}`);
@@ -11,20 +44,24 @@ async function handleResponse<T>(response: Response): Promise<T> {
 }
 
 export async function fetchBots(): Promise<Bot[]> {
-  const response = await fetch(`${API_BASE}/bots`);
+  const response = await fetch(`${API_BASE}/bots`, {
+    headers: getAuthHeaders(),
+  });
   const data = await handleResponse<{ bots: Bot[] }>(response);
   return data.bots;
 }
 
 export async function fetchBot(hostname: string): Promise<Bot> {
-  const response = await fetch(`${API_BASE}/bots/${hostname}`);
+  const response = await fetch(`${API_BASE}/bots/${hostname}`, {
+    headers: getAuthHeaders(),
+  });
   return handleResponse<Bot>(response);
 }
 
 export async function createBot(input: CreateBotInput): Promise<Bot> {
   const response = await fetch(`${API_BASE}/bots`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
     body: JSON.stringify(input),
   });
   return handleResponse<Bot>(response);
@@ -33,6 +70,7 @@ export async function createBot(input: CreateBotInput): Promise<Bot> {
 export async function deleteBot(hostname: string): Promise<void> {
   const response = await fetch(`${API_BASE}/bots/${hostname}`, {
     method: 'DELETE',
+    headers: getAuthHeaders(),
   });
   await handleResponse<{ success: boolean }>(response);
 }
@@ -40,6 +78,7 @@ export async function deleteBot(hostname: string): Promise<void> {
 export async function startBot(hostname: string): Promise<void> {
   const response = await fetch(`${API_BASE}/bots/${hostname}/start`, {
     method: 'POST',
+    headers: getAuthHeaders(),
   });
   await handleResponse<{ success: boolean }>(response);
 }
@@ -47,24 +86,30 @@ export async function startBot(hostname: string): Promise<void> {
 export async function stopBot(hostname: string): Promise<void> {
   const response = await fetch(`${API_BASE}/bots/${hostname}/stop`, {
     method: 'POST',
+    headers: getAuthHeaders(),
   });
   await handleResponse<{ success: boolean }>(response);
 }
 
 export async function fetchContainerStats(): Promise<ContainerStats[]> {
-  const response = await fetch(`${API_BASE}/stats`);
+  const response = await fetch(`${API_BASE}/stats`, {
+    headers: getAuthHeaders(),
+  });
   const data = await handleResponse<{ stats: ContainerStats[] }>(response);
   return data.stats;
 }
 
 export async function fetchOrphans(): Promise<OrphanReport> {
-  const response = await fetch(`${API_BASE}/admin/orphans`);
+  const response = await fetch(`${API_BASE}/admin/orphans`, {
+    headers: getAuthHeaders(),
+  });
   return handleResponse<OrphanReport>(response);
 }
 
 export async function runCleanup(): Promise<CleanupReport> {
   const response = await fetch(`${API_BASE}/admin/cleanup`, {
     method: 'POST',
+    headers: getAuthHeaders(),
   });
   return handleResponse<CleanupReport>(response);
 }
@@ -74,9 +119,10 @@ export async function checkHealth(): Promise<{ status: string; timestamp: string
   return handleResponse<{ status: string; timestamp: string }>(response);
 }
 
-// Proxy key management
 export async function fetchProxyKeys(): Promise<ProxyKey[]> {
-  const response = await fetch(`${API_BASE}/proxy/keys`);
+  const response = await fetch(`${API_BASE}/proxy/keys`, {
+    headers: getAuthHeaders(),
+  });
   const data = await handleResponse<{ keys: ProxyKey[] }>(response);
   return data.keys;
 }
@@ -84,7 +130,7 @@ export async function fetchProxyKeys(): Promise<ProxyKey[]> {
 export async function addProxyKey(input: AddKeyInput): Promise<{ id: string }> {
   const response = await fetch(`${API_BASE}/proxy/keys`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
     body: JSON.stringify(input),
   });
   return handleResponse<{ id: string }>(response);
@@ -93,11 +139,14 @@ export async function addProxyKey(input: AddKeyInput): Promise<{ id: string }> {
 export async function deleteProxyKey(id: string): Promise<void> {
   const response = await fetch(`${API_BASE}/proxy/keys/${id}`, {
     method: 'DELETE',
+    headers: getAuthHeaders(),
   });
   await handleResponse<{ ok: boolean }>(response);
 }
 
 export async function fetchProxyHealth(): Promise<ProxyHealthResponse> {
-  const response = await fetch(`${API_BASE}/proxy/health`);
+  const response = await fetch(`${API_BASE}/proxy/health`, {
+    headers: getAuthHeaders(),
+  });
   return handleResponse<ProxyHealthResponse>(response);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "botmaker",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "botmaker",
-      "version": "0.5.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/basic-auth": "^6.0.0",
+        "@fastify/helmet": "^13.0.2",
+        "@fastify/rate-limit": "^10.3.0",
         "@fastify/static": "^8.0.0",
         "better-sqlite3": "^11.6.0",
         "dockerode": "^4.0.4",
@@ -827,6 +829,26 @@
       ],
       "license": "MIT"
     },
+    "node_modules/@fastify/helmet": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-13.0.2.tgz",
+      "integrity": "sha512-tO1QMkOfNeCt9l4sG/FiWErH4QMm+RjHzbMTrgew1DYOQ2vb/6M1G2iNABBrD7Xq6dUk+HLzWW8u+rmmhQHifA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0",
+        "helmet": "^8.0.0"
+      }
+    },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
@@ -864,6 +886,27 @@
       "dependencies": {
         "@fastify/forwarded": "^3.0.0",
         "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/rate-limit": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-10.3.0.tgz",
+      "integrity": "sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "fastify-plugin": "^5.0.0",
+        "toad-cache": "^3.7.0"
       }
     },
     "node_modules/@fastify/send": {
@@ -1686,6 +1729,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2055,6 +2099,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2778,6 +2823,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3336,6 +3382,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/html-escaper": {
@@ -4023,6 +4078,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5028,6 +5084,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5101,6 +5158,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -5614,6 +5672,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
   },
   "dependencies": {
     "@fastify/basic-auth": "^6.0.0",
+    "@fastify/helmet": "^13.0.2",
+    "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^8.0.0",
     "better-sqlite3": "^11.6.0",
     "dockerode": "^4.0.4",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -8,6 +8,8 @@
       "name": "keyring-proxy",
       "version": "1.0.0",
       "dependencies": {
+        "@fastify/helmet": "^13.0.2",
+        "@fastify/rate-limit": "^10.3.0",
         "better-sqlite3": "^11.6.0",
         "fastify": "^5.1.0",
         "uuid": "^11.0.0"
@@ -632,6 +634,26 @@
       ],
       "license": "MIT"
     },
+    "node_modules/@fastify/helmet": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-13.0.2.tgz",
+      "integrity": "sha512-tO1QMkOfNeCt9l4sG/FiWErH4QMm+RjHzbMTrgew1DYOQ2vb/6M1G2iNABBrD7Xq6dUk+HLzWW8u+rmmhQHifA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0",
+        "helmet": "^8.0.0"
+      }
+    },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
@@ -669,6 +691,27 @@
       "dependencies": {
         "@fastify/forwarded": "^3.0.0",
         "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/rate-limit": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-10.3.0.tgz",
+      "integrity": "sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "fastify-plugin": "^5.0.0",
+        "toad-cache": "^3.7.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -736,6 +779,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@pinojs/redact": {
@@ -2229,6 +2281,22 @@
         "toad-cache": "^3.7.0"
       }
     },
+    "node_modules/fastify-plugin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -2344,6 +2412,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/html-escaper": {
@@ -3546,6 +3623,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3685,6 +3763,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -13,6 +13,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@fastify/helmet": "^13.0.2",
+    "@fastify/rate-limit": "^10.3.0",
     "better-sqlite3": "^11.6.0",
     "fastify": "^5.1.0",
     "uuid": "^11.0.0"

--- a/proxy/src/index.ts
+++ b/proxy/src/index.ts
@@ -1,4 +1,6 @@
 import Fastify from 'fastify';
+import fastifyRateLimit from '@fastify/rate-limit';
+import fastifyHelmet from '@fastify/helmet';
 import { loadConfig } from './config.js';
 import { ProxyDatabase } from './db/index.js';
 import { KeyringService } from './services/keyring.js';
@@ -16,6 +18,11 @@ async function main(): Promise<void> {
 
   // Create admin server
   const adminApp = Fastify({ logger: true });
+  await adminApp.register(fastifyHelmet);
+  await adminApp.register(fastifyRateLimit, {
+    max: 100,
+    timeWindow: '1 minute',
+  });
   adminApp.addContentTypeParser(
     'application/json',
     { parseAs: 'string' },
@@ -31,6 +38,11 @@ async function main(): Promise<void> {
 
   // Create data plane server
   const dataApp = Fastify({ logger: true });
+  await dataApp.register(fastifyHelmet);
+  await dataApp.register(fastifyRateLimit, {
+    max: 1000,
+    timeWindow: '1 minute',
+  });
 
   // Parse JSON and raw bodies for proxy
   dataApp.addContentTypeParser(


### PR DESCRIPTION
- Add authentication with `ADMIN_TOKEN` env var and Bearer token validation on all /api/* routes
- Add rate limiting (100 req/min) to main server and proxy (100/1000 req/min admin/data)
- Fix timing attack in token comparison by padding buffers before `timingSafeEqual`
- Add 30-second request timeouts to all proxy client fetch calls
- Add `@fastify/helmet` security headers to both servers
- Add Authorization header support to dashboard API calls