### PR TITLE
fix: forward vendor-specific headers through proxy

### DIFF
--- a/proxy/src/routes/proxy.ts
+++ b/proxy/src/routes/proxy.ts
@@ -73,9 +73,10 @@ export function registerProxyRoutes(
       keyId = keySelection.keyId;
     }
 
-    const FORWARDED_HEADERS = ['content-type', 'accept', 'user-agent'];
+    const COMMON_HEADERS = ['content-type', 'accept', 'user-agent'];
+    const forwardHeaders = [...COMMON_HEADERS, ...(vendorConfig.forwardHeaders ?? [])];
     const headers: Record<string, string> = {};
-    for (const name of FORWARDED_HEADERS) {
+    for (const name of forwardHeaders) {
       const value = req.headers[name];
       if (typeof value === 'string') {
         headers[name] = value;

--- a/proxy/src/types.ts
+++ b/proxy/src/types.ts
@@ -33,6 +33,7 @@ export interface VendorConfig {
   protocol?: 'http' | 'https'; // default: 'https'
   noAuth?: boolean;            // Skip API key injection (e.g., local Ollama)
   forceNonStreaming?: boolean;  // Strip stream:true, convert response to SSE
+  forwardHeaders?: string[];   // Extra vendor-specific headers to forward from client
 }
 
 const VENDOR_CONFIGS: Record<string, VendorConfig> = {
@@ -47,6 +48,7 @@ const VENDOR_CONFIGS: Record<string, VendorConfig> = {
     basePath: '', // OpenClaw's anthropic-messages API includes /v1 in its path
     authHeader: 'x-api-key',
     authFormat: (key) => key,
+    forwardHeaders: ['anthropic-version', 'anthropic-beta'],
   },
   venice: {
     host: 'api.venice.ai',


### PR DESCRIPTION
## Summary
- Anthropic's API requires `anthropic-version` header on all requests — the proxy was stripping it, causing 400 errors for any Anthropic model
- Add `forwardHeaders` field to `VendorConfig` so each vendor declares its own extra headers to forward
- Anthropic config gets `anthropic-version` and `anthropic-beta`; all other vendors are unaffected

## Test plan
- [ ] Verify Anthropic model calls succeed through the proxy (no more `anthropic-version: header is required` errors)
- [ ] Verify Google/OpenAI/other vendors still work (no regressions from the header change)
- [ ] Run `npm test` in `proxy/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)