### PR TITLE
fix: resolve ESLint errors in config, server, and CaddyService

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -100,7 +100,7 @@ export function getConfig(): AppConfig {
     proxyAdminToken,
     adminPassword,
     sessionExpiryMs: getEnvIntOrDefault('SESSION_EXPIRY_MS', 24 * 60 * 60 * 1000),
-    publicHost: process.env.PUBLIC_HOST?.trim() || null,
+    publicHost: process.env.PUBLIC_HOST?.trim() || null, // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing -- intentionally treats empty string as null
     caddyEnabled: process.env.CADDY_ENABLED === 'true',
   };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -365,7 +365,7 @@ export async function buildServer(): Promise<FastifyInstance> {
   if (config.caddyEnabled && config.publicHost) {
     const runningBots = listBots()
       .filter(b => b.status === 'running' && b.port != null)
-      .map(b => ({ hostname: b.hostname, port: b.port as number }));
+      .map(b => ({ hostname: b.hostname, port: Number(b.port) }));
     const restored = await getCaddy(config.publicHost).restoreRoutes(
       runningBots, BOT_INTERNAL_PORT, server.log,
     );

--- a/src/services/CaddyService.ts
+++ b/src/services/CaddyService.ts
@@ -47,7 +47,7 @@ export class CaddyService {
     try {
       const container = this.docker.getContainer(containerName);
       const info = await container.inspect();
-      const networks = info.NetworkSettings.Networks;
+      const networks: Record<string, { IPAddress: string } | undefined> = info.NetworkSettings.Networks;
       const networkInfo = networks[this.networkName];
 
       if (!networkInfo) {
@@ -147,7 +147,7 @@ export class CaddyService {
    * @returns Number of routes successfully restored
    */
   async restoreRoutes(
-    bots: Array<{ hostname: string; port: number }>,
+    bots: { hostname: string; port: number }[],
     internalPort: number,
     logger: { info: (msg: string | object, ...args: unknown[]) => void; warn: (msg: string | object, ...args: unknown[]) => void },
   ): Promise<number> {


### PR DESCRIPTION
- Use nullish coalescing where safe, suppress where || is intentional
- Replace `as number` cast with Number() conversion in server.ts
- Use T[] array syntax instead of Array<T> in CaddyService
- Add explicit Record type to fix no-unnecessary-condition lint error